### PR TITLE
Ts update popular vehicles view

### DIFF
--- a/carnivalproject/carnivalapi/models/__init__.py
+++ b/carnivalproject/carnivalapi/models/__init__.py
@@ -1,6 +1,7 @@
 from .sale import Sale
 from .saletype import SaleType
 from .vehicle import Vehicle
+from .popularvehicle import PopularVehicle
 from .dealership import Dealership
 from .vehicletype import VehicleType
 from .vehiclemodel import VehicleModel

--- a/carnivalproject/carnivalapi/models/popularvehicle.py
+++ b/carnivalproject/carnivalapi/models/popularvehicle.py
@@ -1,0 +1,19 @@
+from django.db import models
+from django.urls import reverse
+
+class PopularVehicle(models.Model):
+    
+    vehicles_sold = models.IntegerField(null=True)
+    body_type = models.CharField(max_length=20, null=True)
+    make = models.CharField(max_length=20, null=True)
+    model = models.CharField(max_length=20, null=True)
+
+    class Meta:
+        verbose_name = ("Popular Vehicle")
+        verbose_name_plural = ("Popular Vehicles")        
+        
+    def __str__(self):
+        return f"Popular Vehicle ID: {self.pk}"
+    
+    def get_absolute_url(self):
+        return reverse("popular_vehicle_detail", kwargs={"pk": self.pk})

--- a/carnivalproject/carnivalapi/views/vehicle.py
+++ b/carnivalproject/carnivalapi/views/vehicle.py
@@ -1,9 +1,10 @@
 from django.http import HttpResponseServerError
+from django.core import serializers as Serializers
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
-from ..models import Vehicle, VehicleType
+from ..models import Vehicle, VehicleType, PopularVehicle
 from .vehicletype import VehicleTypeSerializer
 
 class VehicleSerializer(serializers.HyperlinkedModelSerializer):
@@ -17,16 +18,16 @@ class VehicleSerializer(serializers.HyperlinkedModelSerializer):
         fields = ('id', 'vin', 'engine_type', 'vehicle_type', 'exterior_color', 'interior_color', 'floor_price', 'msr_price', 'miles_count', 'year_of_car', 'is_sold', 'vehicle_type_id')
 
         depth = 1
-
-class VehicleTypeSerializer(serializers.HyperlinkedModelSerializer):
+        
+class PopularVehicleSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
-        model = VehicleType
+        model = PopularVehicle
         url = serializers.HyperlinkedIdentityField(
-            view_name='VehicleType',
+            view_name='PopularVehicle',
             lookup_field='id'
         )
-        fields = ('id', 'body_type', 'make', 'model')
+        fields = ('id', 'vehicles_sold', 'make', 'model')
 
 class Vehicles(ViewSet):
 
@@ -113,7 +114,7 @@ class Vehicles(ViewSet):
         if popular_models is not None:
             popular_vehicles = Vehicle.objects.raw('select * from popular_vehicles;')
             
-            serializer = VehicleTypeSerializer(
+            serializer = PopularVehicleSerializer(
             popular_vehicles, many=True, context={'request': request})
 
             return Response(serializer.data)

--- a/carnivalproject/carnivalproject/urls.py
+++ b/carnivalproject/carnivalproject/urls.py
@@ -28,13 +28,10 @@ router.register(r'dealershipemployees', DealershipEmployees, 'dealershipemployee
 router.register(r'employees', Employees, 'employee')
 router.register(r'employeetypes', EmployeeTypes, 'employeetype')
 router.register(r'vehicletypes', VehicleTypes, 'vehicletype')
-# router.register(r'vehiclebodytypes', VehicleBodyTypes, 'vehiclebodytype')
 router.register(r'repairtypes', RepairTypes, 'repairtype')
 router.register(r'oilchangelogs', OilChangeLogs, 'oilchangelog')
 router.register(r'saletypes', SaleTypes, 'saletype')
 router.register(r'vehicles', Vehicles, 'vehicle')
-# router.register(r'vehiclemakes', VehicleMakes, 'vehiclemakes')
-# router.register(r'vehiclemodels', VehicleModels, 'vehiclemodels')
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
- Added new custom model called 'PopularVehicle' in `models/popularvehicle.py` so that we could run a custom serializer to fetch the correct columns from the custom SQL view 'popular_vehicles'

- Removed commented-out routes in urls.py that aren't being used

- Replaced 'VehicleTypeSerializer' with 'PopularVehicleSerializer' in `views/vehicle.py` so now we are getting all the fields from the SQL view back (wanted to display the # of vehicles sold for each of the top 5 most popular vehicles)