### PR TITLE
added a vehicleType search term for a smaller query when selecting th…

### DIFF
--- a/carnivalproject/carnivalapi/views/vehicletype.py
+++ b/carnivalproject/carnivalapi/views/vehicletype.py
@@ -91,6 +91,7 @@ class VehicleTypes(ViewSet):
 
         limit = self.request.query_params.get('limit')
         searchVal = self.request.query_params.get('searchTerm')
+        searchValVT = self.request.query_params.get('searchTermVT')
 
         if limit is not None:
             vehicletype = VehicleType.objects.all()[:int(limit)]
@@ -104,6 +105,10 @@ class VehicleTypes(ViewSet):
                                 FROM carnivalapi_vehicle v
                                 LEFT JOIN carnivalapi_vehicletype vt ON v.vehicle_type_id = vt.id
                                 WHERE vt.make ILIKE %s OR vt.model ILIKE %s;""",[searchVal+'%', searchVal+'%'])
+
+        elif searchValVT is not None:
+            cursor = connection.cursor()
+            cursor.execute("SELECT * FROM carnivalapi_vehicletype WHERE make ILIKE %s OR model ILIKE %s", [searchValVT+'%', searchValVT+'%'])
 
             def dictfetchall(cursor):
                 "Return all rows from a cursor as a dict"


### PR DESCRIPTION
Added a vehicleType search term for a smaller query when selecting the ID of the vehicle type for edit

**COPY PASTA THIS TO YOUR TERMINAL**

```git fetch --all```
```git checkout jg-edit-vt-search```
```python manage.py runserver```


You can now test this branch with your post man and run the following commands:

**THE RESULTS MAY VARY AS THIS IS ASSUMING YOU ARE USING WHAT IS MUTUALLY SHARE IN OUR DB**

http://127.0.0.1:8000/vehicletypes?searchTermVT=co

This should return 1 result

[
    {
        "id": 1,
        "body_type": "Car",
        "make": "Chevrolet",
        "model": "Corvette"
    }
]

http://127.0.0.1:8000/vehicletypes?searchTermVT=c

And this should return 5 results

[
    {
        "id": 1,
        "body_type": "Car",
        "make": "Chevrolet",
        "model": "Corvette"
    },
    {
        "id": 2,
        "body_type": "SUV",
        "make": "Chevrolet",
        "model": "Blazer"
    },
    {
        "id": 3,
        "body_type": "SUV",
        "make": "Mazda",
        "model": "CX-5"
    },
    {
        "id": 5,
        "body_type": "Truck",
        "make": "Chevrolet",
        "model": "Silverado"
    },
    {
        "id": 9,
        "body_type": "Car",
        "make": "Mazda",
        "model": "CX-9"
    }
]