### PR TITLE
added a new sql custom read only function into the sales view that returns a single joined table object containing both customer and sale props

### DIFF
--- a/carnivalproject/carnivalapi/views/sale.py
+++ b/carnivalproject/carnivalapi/views/sale.py
@@ -100,15 +100,24 @@ class Sales(ViewSet):
     def retrieve(self, request, pk=None):
 
         try:
-            sale = Sale.objects.get(pk=pk)
+            cursor = connection.cursor()
+            cursor.execute("""SELECT * FROM one_sale_with_one_customer(%s)""",[pk])
+
+            
 
             # cursor = connection.cursor()
             # cursor.execute('''SELECT count(*) FROM people_person''')
 
-            serializer = SaleSerializer(
-                sale, context={'request': request})
+            def dictfetchall(cursor):
+                "Return all rows from a cursor as a dict"
+                columns = [col[0] for col in cursor.description]
+                return [
+                    dict(zip(columns, row))
+                    for row in cursor.fetchall()
+                ]
 
-            return Response(serializer.data)
+            return Response(dictfetchall(cursor))
+
 
         except Exception as ex:
             return HttpResponseServerError(ex)


### PR DESCRIPTION
git fetch --all 
git checkout ss-100--Sale
 
run server

1.  add this view to your database

```
create or replace function one_sale_with_one_customer(saleId integer)
       returns table (id integer,sales_type_id integer ,vehicle_id integer, employee_id integer, customer_id integer,dealership_id integer,price numeric, deposit integer, purchase_date date, pickup_date date, invoice_number varchar, payment_method varchar, returned bool, c_id integer, first_name varchar, last_name varchar, email varchar, phone varchar, street varchar, city varchar, state varchar, zipcode varchar, company_name varchar,st_id integer, name varchar)
       LANGUAGE 'plpgsql'
AS
$$
BEGIN
RETURN QUERY 
    SELECT * FROM carnivalapi_sale s
    JOIN carnivalapi_customer c ON s.customer_id = c.id
    JOIN carnivalapi_saletype st ON s.sales_type_id = st.id
    Where s.id = saleId;
END
$$;
```
Then test this function in pgADmin using the below query

`SELECT * FROM one_sale_with_one_customer(1001)`

3rd
test the sales/1001 endpoint in postman to get a joined table object of both sale and customer data